### PR TITLE
Support environment name as parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+locals {
+  environment = var.environment != "" ? var.environment : terraform.workspace
+}
+
 module "deploy" {
   source     = "./modules/deploy"
   project_id = var.project_id
@@ -23,6 +27,7 @@ module "deploy" {
 module "convertfeed" {
   source                     = "./modules/convertfeed"
   project_id                 = var.project_id
+  environment                = local.environment
   pubsub_allowed_regions     = var.pubsub_allowed_regions
   crun_region                = var.crun_region
   ram_microservice_image_tag = var.ram_microservice_image_tag
@@ -32,6 +37,7 @@ module "convertfeed" {
 module "fetchrules" {
   source                     = "./modules/fetchrules"
   project_id                 = var.project_id
+  environment                = local.environment
   pubsub_allowed_regions     = var.pubsub_allowed_regions
   gcs_location               = var.gcs_location
   crun_region                = var.crun_region
@@ -43,6 +49,7 @@ module "fetchrules" {
 module "monitor" {
   source                     = "./modules/monitor"
   project_id                 = var.project_id
+  environment                = local.environment
   pubsub_allowed_regions     = var.pubsub_allowed_regions
   crun_region                = var.crun_region
   ram_microservice_image_tag = var.ram_microservice_image_tag
@@ -53,6 +60,7 @@ module "monitor" {
 module "stream2bq" {
   source                     = "./modules/stream2bq"
   project_id                 = var.project_id
+  environment                = local.environment
   views_interval_days        = var.views_interval_days
   bq_partition_expiration_ms = var.bq_partition_expiration_ms
   crun_region                = var.crun_region
@@ -66,6 +74,7 @@ module "stream2bq" {
 module "launch" {
   source                     = "./modules/launch"
   project_id                 = var.project_id
+  environment                = local.environment
   pubsub_allowed_regions     = var.pubsub_allowed_regions
   gcs_location               = var.gcs_location
   scheduler_region           = var.scheduler_region
@@ -78,6 +87,7 @@ module "launch" {
 module "executecaiexport" {
   source                     = "./modules/executecaiexport"
   project_id                 = var.project_id
+  environment                = local.environment
   gcs_location               = var.gcs_location
   export_org_ids             = var.export_org_ids
   export_folder_ids          = var.export_folder_ids
@@ -90,6 +100,7 @@ module "executecaiexport" {
 module "executegfsdeleteolddocs" {
   source                     = "./modules/executegfsdeleteolddocs"
   project_id                 = var.project_id
+  environment                = local.environment
   crun_region                = var.crun_region
   ram_microservice_image_tag = var.ram_microservice_image_tag
   log_only_severity_levels   = var.log_only_severity_levels
@@ -99,6 +110,7 @@ module "executegfsdeleteolddocs" {
 module "splitexport" {
   source                     = "./modules/splitexport"
   project_id                 = var.project_id
+  environment                = local.environment
   pubsub_allowed_regions     = var.pubsub_allowed_regions
   crun_region                = var.crun_region
   ram_microservice_image_tag = var.ram_microservice_image_tag
@@ -110,6 +122,7 @@ module "splitexport" {
 module "publish2fs" {
   source                     = "./modules/publish2fs"
   project_id                 = var.project_id
+  environment                = local.environment
   crun_region                = var.crun_region
   ram_microservice_image_tag = var.ram_microservice_image_tag
   log_only_severity_levels   = var.log_only_severity_levels
@@ -119,6 +132,7 @@ module "publish2fs" {
 module "upload2gcs" {
   source                     = "./modules/upload2gcs"
   project_id                 = var.project_id
+  environment                = local.environment
   gcs_location               = var.gcs_location
   crun_region                = var.crun_region
   ram_microservice_image_tag = var.ram_microservice_image_tag

--- a/modules/convertfeed/main.tf
+++ b/modules/convertfeed/main.tf
@@ -88,7 +88,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/convertfeed/variables.tf
+++ b/modules/convertfeed/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "cai_feed_topic_name" {
   description = "google cloud asset inventory feed messages"
   default     = "caiFeed"

--- a/modules/executecaiexport/main.tf
+++ b/modules/executecaiexport/main.tf
@@ -95,7 +95,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/executecaiexport/variables.tf
+++ b/modules/executecaiexport/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "gcs_location" {
   description = "Cloud Storage location"
   default     = "europe-west1"

--- a/modules/executegfsdeleteolddocs/main.tf
+++ b/modules/executegfsdeleteolddocs/main.tf
@@ -60,7 +60,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/executegfsdeleteolddocs/variables.tf
+++ b/modules/executegfsdeleteolddocs/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "crun_region" {
   description = "cloud run region"
   default     = "europe-west1"

--- a/modules/fetchrules/main.tf
+++ b/modules/fetchrules/main.tf
@@ -93,7 +93,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/fetchrules/variables.tf
+++ b/modules/fetchrules/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "asset_rule_topic_name" {
   description = "each message combines the data of one asset and the code of one complicance rule's"
   default     = "assetRule"

--- a/modules/launch/main.tf
+++ b/modules/launch/main.tf
@@ -82,7 +82,7 @@ resource "google_pubsub_topic" "action_trigger" {
 resource "google_cloud_scheduler_job" "job" {
   for_each = {
     for name, s in var.schedulers : name => s
-    if s.environment == terraform.workspace
+    if s.environment == var.environment
   }
   project     = var.project_id
   name        = each.value.name
@@ -113,7 +113,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/launch/variables.tf
+++ b/modules/launch/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "action_topic_name" {
   description = "the message body is the action to be executed"
   default     = "action"

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -96,7 +96,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/monitor/variables.tf
+++ b/modules/monitor/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "compliance_status_topic_name" {
   description = "compliance status may be true for compliant or false for not compliant for a given asset version and configuration rule version"
   default     = "ram-complianceStatus"

--- a/modules/publish2fs/main.tf
+++ b/modules/publish2fs/main.tf
@@ -63,7 +63,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/publish2fs/variables.tf
+++ b/modules/publish2fs/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "crun_region" {
   description = "cloud run region"
   default     = "europe-west1"

--- a/modules/splitexport/main.tf
+++ b/modules/splitexport/main.tf
@@ -92,7 +92,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/splitexport/variables.tf
+++ b/modules/splitexport/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "exports_bucket_name" {
   description = "Cloud storage bucket where to output Cloud Asset Inventory exports"
 }

--- a/modules/stream2bq/main.tf
+++ b/modules/stream2bq/main.tf
@@ -657,7 +657,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/stream2bq/variables.tf
+++ b/modules/stream2bq/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "dataset_name" {
   description = "Bigquery dataset name"
   default     = "ram"

--- a/modules/upload2gcs/main.tf
+++ b/modules/upload2gcs/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "crun_svc" {
         }
         env {
           name  = "${upper(local.service_name)}_ENVIRONMENT"
-          value = terraform.workspace
+          value = var.environment
         }
         env {
           name  = "${upper(local.service_name)}_LOG_ONLY_SEVERITY_LEVELS"

--- a/modules/upload2gcs/variables.tf
+++ b/modules/upload2gcs/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   description = "RAM GCP project id for a given environment, like dev or production"
 }
 
+variable "environment" {
+  description = "environment name"
+}
+
 variable "gcs_location" {
   description = "Cloud Storage location"
   default     = "europe-west1"

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,11 @@ variable "project_id" {
   description = "GCP project id where to deploy RAM for a given environment, like test or production"
 }
 
+variable "environment" {
+  description = "environment name, by default terraform.workspace is used"
+  default     = ""
+}
+
 variable "ram_microservice_image_tag" {
   description = "The container image tag for this microservice"
   default     = "latest"


### PR DESCRIPTION
Allow users to overwrite the environment name, instead of always using terraform.workspace.

Some users may want to configure it, for example if they do not use terraform workspaces to differentiate between environments.

Signed-off-by: Christian Schroer <christian.schroer@metro-external.digital>